### PR TITLE
Adding project_name to isort src paths

### DIFF
--- a/fastapi_template/template/{{cookiecutter.project_name}}/pyproject.toml
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/pyproject.toml
@@ -84,6 +84,7 @@ asynctest = "^0.13.0"
 [tool.isort]
 profile = "black"
 multi_line_output = 3
+src_paths = ["{{cookiecutter.project_name}}",]
 
 [tool.mypy]
 strict = true


### PR DESCRIPTION
This will prevent isort from grouping 1st party and 3rd party imports together