### PR TITLE
use kube_name on namespace

### DIFF
--- a/fastapi_template/template/{{cookiecutter.project_name}}/deploy/kube/namespace.yml
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/deploy/kube/namespace.yml
@@ -2,6 +2,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: "{{cookiecutter.project_name}}"
+  name: "{{cookiecutter.kube_name}}"
 
 ---


### PR DESCRIPTION
fixes #36 
just noticed there was this variable available and it's actually used on the other parts of the k8s deploy files