### PR TITLE
Change psycopg dependencies

### DIFF
--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/db_psycopg/dao/dummy_dao.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/db_psycopg/dao/dummy_dao.py
@@ -41,7 +41,7 @@ class DummyDAO:
         :param offset: offset of dummies.
         :return: stream of dummies.
         """
-        async with self.db_pool as connection:
+        async with self.db_pool.connection() as connection:
             async with connection.cursor(
                 binary=True,
                 row_factory=class_row(DummyModel)
@@ -65,7 +65,7 @@ class DummyDAO:
         :param name: name of dummy instance.
         :return: dummy models.
         """
-        async with self.db_pool as connection:
+        async with self.db_pool.connection() as connection:
             async with connection.cursor(
                 binary=True,
                 row_factory=class_row(DummyModel)

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/db_psycopg/dao/dummy_dao.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/db_psycopg/dao/dummy_dao.py
@@ -3,9 +3,9 @@ from {{cookiecutter.project_name}}.db.models.dummy_model import DummyModel
 from typing import Any
 
 from fastapi import Depends
-from psycopg import AsyncConnection
+from psycopg_pool import ConnectionPool
 from psycopg.rows import class_row
-from {{cookiecutter.project_name}}.db.dependencies import get_db_session
+from {{cookiecutter.project_name}}.db.dependencies import get_db_pool
 from typing import List, Optional
 
 class DummyDAO:
@@ -13,9 +13,9 @@ class DummyDAO:
 
     def __init__(
         self,
-        connection: AsyncConnection[Any] = Depends(get_db_session),
+        db_pool: ConnectionPool = Depends(get_db_pool),
     ):
-        self.connection = connection
+        self.db_pool = db_pool
 
 
     async def create_dummy_model(self, name: str) -> None:
@@ -24,15 +24,14 @@ class DummyDAO:
 
         :param name: name of a dummy.
         """
-        async with self.connection.cursor(
-            binary=True,
-        ) as cur:
-            await cur.execute(
-                "INSERT INTO dummy (name) VALUES (%(name)s);",
-                params={
-                    "name": name,
-                }
-            )
+        async with self.db_pool.connection() as connection:
+            async with connection.cursor(binary=True) as cur:
+                await cur.execute(
+                    "INSERT INTO dummy (name) VALUES (%(name)s);",
+                    params={
+                        "name": name,
+                    }
+                )
 
     async def get_all_dummies(self, limit: int, offset: int) -> List[DummyModel]:
         """
@@ -42,18 +41,19 @@ class DummyDAO:
         :param offset: offset of dummies.
         :return: stream of dummies.
         """
-        async with self.connection.cursor(
-            binary=True,
-            row_factory=class_row(DummyModel)
-        ) as cur:
-            res = await cur.execute(
-                "SELECT id, name FROM dummy LIMIT %(limit)s OFFSET %(offset)s;",
-                params={
-                    "limit": limit,
-                    "offset": offset,
-                }
-            )
-            return await res.fetchall()
+        async with self.db_pool as connection:
+            async with connection.cursor(
+                binary=True,
+                row_factory=class_row(DummyModel)
+            ) as cur:
+                res = await cur.execute(
+                    "SELECT id, name FROM dummy LIMIT %(limit)s OFFSET %(offset)s;",
+                    params={
+                        "limit": limit,
+                        "offset": offset,
+                    }
+                )
+                return await res.fetchall()
 
     async def filter(
         self,
@@ -65,17 +65,18 @@ class DummyDAO:
         :param name: name of dummy instance.
         :return: dummy models.
         """
-        async with self.connection.cursor(
-            binary=True,
-            row_factory=class_row(DummyModel)
-        ) as cur:
-            if name is not None:
-                res = await cur.execute(
-                    "SELECT id, name FROM dummy WHERE name=%(name)s;",
-                    params={
-                        "name": name,
-                    }
-                )
-            else:
-                res = await cur.execute("SELECT id, name FROM dummy;")
-            return await res.fetchall()
+        async with self.db_pool as connection:
+            async with connection.cursor(
+                binary=True,
+                row_factory=class_row(DummyModel)
+            ) as cur:
+                if name is not None:
+                    res = await cur.execute(
+                        "SELECT id, name FROM dummy WHERE name=%(name)s;",
+                        params={
+                            "name": name,
+                        }
+                    )
+                else:
+                    res = await cur.execute("SELECT id, name FROM dummy;")
+                return await res.fetchall()

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/db_psycopg/dependencies.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/db_psycopg/dependencies.py
@@ -1,20 +1,12 @@
-from typing import Any, AsyncGenerator
-
-from psycopg import AsyncConnection
+from psycopg_pool import ConnectionPool
 from starlette.requests import Request
 
 
-async def get_db_session(
-    request: Request,
-) -> AsyncGenerator[AsyncConnection[Any], None]:
+async def get_db_pool(request: Request) -> ConnectionPool:
     """
-    Create and get database connection.
+    Return database connections pool.
 
     :param request: current request.
-    :yield: database connection.
+    :returns: database connections pool.
     """
-    async with request.app.state.db_pool.connection() as conn:
-        try:
-            yield conn
-        except Exception:  # noqa: S110
-            pass  # noqa: WPS420
+    return request.app.state.db_pool


### PR DESCRIPTION
Hello!
I found out that in the case of using psycopg dependency in a view, a situation is possible when the connection is allocated, but not used.

For example, if we need to execute a request for some third-party service before requesting the database.

Therefore, I suggest not taking the connection in dependency, but return the connection pool so that it is necessary to explicitly occupy the connection when it is needed