### PR TITLE
Removed redundant files.

### DIFF
--- a/fastapi_template/template/{{cookiecutter.project_name}}/aerich.ini
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/aerich.ini
@@ -1,4 +1,0 @@
-[aerich]
-tortoise_orm = {{cookiecutter.project_name}}.db.config.TORTOISE_CONFIG
-location = ./{{cookiecutter.project_name}}/db/migrations
-src_folder = ./{{cookiecutter.project_name}}

--- a/fastapi_template/template/{{cookiecutter.project_name}}/conditional_files.json
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/conditional_files.json
@@ -114,9 +114,12 @@
             "{{cookiecutter.project_name}}/web/gql/redis",
             "{{cookiecutter.project_name}}/web/api/kafka",
             "{{cookiecutter.project_name}}/web/gql/kafka",
+            "{{cookiecutter.project_name}}/web/api/rabbit",
+            "{{cookiecutter.project_name}}/web/gql/rabbit",
             "{{cookiecutter.project_name}}/tests/test_echo.py",
             "{{cookiecutter.project_name}}/tests/test_dummy.py",
-            "{{cookiecutter.project_name}}/tests/test_redis.py"
+            "{{cookiecutter.project_name}}/tests/test_redis.py",
+            "{{cookiecutter.project_name}}/tests/test_rabbit.py"
         ]
     },
     "Dummy model": {

--- a/fastapi_template/template/{{cookiecutter.project_name}}/conditional_files.json
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/conditional_files.json
@@ -53,7 +53,6 @@
     "Database support": {
         "enabled": "{{cookiecutter.db_info.name != 'none'}}",
         "resources": [
-            "aerich.ini",
             "alembic.ini",
             "{{cookiecutter.project_name}}/web/api/dummy",
             "{{cookiecutter.project_name}}/web/gql/dummy",
@@ -71,7 +70,6 @@
     "Migrations": {
         "enabled": "{{cookiecutter.enable_migrations}}",
         "resources": [
-            "aerich.ini",
             "alembic.ini",
             "{{cookiecutter.project_name}}/db_sa/migrations",
             "{{cookiecutter.project_name}}/db_ormar/migrations",
@@ -162,7 +160,6 @@
     "Tortoise ORM": {
         "enabled": "{{cookiecutter.orm == 'tortoise'}}",
         "resources": [
-            "aerich.ini",
             "{{cookiecutter.project_name}}/db_tortoise"
         ]
     },


### PR DESCRIPTION
Rabbitmq routes and tests are still present, even if demo routers option isn't chosen.

Also I removed aerich.ini file, since new versions of aerich don't use it.

Signed-off-by: Pavel Kirilin <win10@list.ru>