### PR TITLE
install gcc when postgresql database is chose

### DIFF
--- a/fastapi_template/template/{{cookiecutter.project_name}}/deploy/Dockerfile
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/deploy/Dockerfile
@@ -1,11 +1,19 @@
 FROM python:3.9.6-slim-buster
 
-{%- if cookiecutter.db_info.name == "mysql" %}
+{%- if cookiecutter.db_info.name == "mysql" or cookiecutter.db_info.name == "postgresql" %}
 RUN apt-get update && apt-get install -y \
   default-libmysqlclient-dev \
   gcc \
   && rm -rf /var/lib/apt/lists/*
 {%- endif %}
+
+
+{%- if cookiecutter.db_info.name == "postgresql" %}
+RUN apt-get update && apt-get install -y \
+  gcc \
+  && rm -rf /var/lib/apt/lists/*
+{%- endif %}
+
 
 RUN pip install poetry==1.1.13
 
@@ -19,7 +27,7 @@ WORKDIR /app/src
 # Installing requirements
 RUN poetry install
 
-{%- if cookiecutter.db_info.name == "mysql" %}
+{%- if cookiecutter.db_info.name == "mysql" or cookiecutter.db_info.name == "postgresql" %}
 # Removing gcc
 RUN apt-get purge -y \
   gcc \

--- a/fastapi_template/template/{{cookiecutter.project_name}}/deploy/Dockerfile
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/deploy/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9.6-slim-buster
 
-{%- if cookiecutter.db_info.name == "mysql" or cookiecutter.db_info.name == "postgresql" %}
+{%- if cookiecutter.db_info.name == "mysql" %}
 RUN apt-get update && apt-get install -y \
   default-libmysqlclient-dev \
   gcc \


### PR DESCRIPTION
an error occurs during the build of docker when postgresql is chosen as database due to the missing of gcc library

error : 

`#10 23.13         gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/local/include/python3.10 -c asyncpg/pgproto/pgproto.c -o build/temp.linux-aarch64-cpython-310/asyncpg/pgproto/pgproto.o -O2 -fsigned-char -Wall -Wsign-compare -Wconversion
#10 23.13         error: command 'gcc' failed: No such file or directory
#10 23.13         [end of output]
#10 23.13     
#10 23.13     note: This error originates from a subprocess, and is likely not a problem with pip.
#10 23.13     ERROR: Failed building wheel for asyncpg
#10 23.13   Failed to build asyncpg
#10 23.13   ERROR: Could not build wheels for asyncpg, which is required to install pyproject.toml-based projects
#10 23.13   
#10 23.13   [notice] A new release of pip available: 22.2.1 -> 22.2.2
#10 23.13   [notice] To update, run: pip install --upgrade pip
#10 23.13   
#10 23.13 
#10 23.13   at /usr/local/lib/python3.10/site-packages/poetry/utils/env.py:1195 in _run
#10 23.15       1191│                 output = subprocess.check_output(
#10 23.15       1192│                     cmd, stderr=subprocess.STDOUT, **kwargs
#10 23.15       1193│                 )
#10 23.15       1194│         except CalledProcessError as e:
#10 23.15     → 1195│             raise EnvCommandError(e, input=input_)
#10 23.15       1196│ 
#10 23.15       1197│         return decode(output)
#10 23.15       1198│ 
#10 23.15       1199│     def execute(self, bin, *args, **kwargs):
#10 23.15 
------
executor failed running [/bin/sh -c poetry install]: exit code: 1
ERROR: Service 'api' failed to build : Build failed
`