### PR TITLE
fixed ImportError: cannot import name 'parse_env_headers' from 'opent…

### DIFF
--- a/fastapi_template/template/{{cookiecutter.project_name}}/pyproject.toml
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/pyproject.toml
@@ -92,25 +92,25 @@ prometheus-fastapi-instrumentator = "5.9.1"
 sentry-sdk = "^1.9.9"
 {%- endif %}
 {%- if cookiecutter.otlp_enabled == "True" %}
-opentelemetry-api = "^1.13.0"
-opentelemetry-sdk = "^1.13.0"
-opentelemetry-exporter-otlp = "^1.13.0"
-opentelemetry-instrumentation = "^0.34b0"
-opentelemetry-instrumentation-fastapi = "^0.34b0"
+opentelemetry-api = "^1.15.0"
+opentelemetry-sdk = "^1.15.0"
+opentelemetry-exporter-otlp = "^1.15.0"
+opentelemetry-instrumentation = "^0.36b0"
+opentelemetry-instrumentation-fastapi = "^0.36b0"
 {%- if cookiecutter.enable_loguru != "True" %}
-opentelemetry-instrumentation-logging = "^0.34b0"
+opentelemetry-instrumentation-logging = "^0.36b0"
 {%- endif %}
 {%- if cookiecutter.enable_redis == "True" %}
-opentelemetry-instrumentation-redis = "^0.34b0"
+opentelemetry-instrumentation-redis = "^0.36b0"
 {%- endif %}
 {%- if cookiecutter.db_info.name == "postgresql" and cookiecutter.orm in ["ormar", "tortoise"] %}
-opentelemetry-instrumentation-asyncpg = "^0.34b0"
+opentelemetry-instrumentation-asyncpg = "^0.36b0"
 {%- endif %}
 {%- if cookiecutter.orm == "sqlalchemy" %}
-opentelemetry-instrumentation-sqlalchemy = "^0.34b0"
+opentelemetry-instrumentation-sqlalchemy = "^0.36b0"
 {%- endif %}
 {%- if cookiecutter.enable_rmq == "True" %}
-opentelemetry-instrumentation-aio-pika = "^0.34b0"
+opentelemetry-instrumentation-aio-pika = "^0.36b0"
 {%- endif %}
 {%- endif %}
 {%- if cookiecutter.enable_loguru == "True" %}


### PR DESCRIPTION
I was getting `ImportError: cannot import name 'parse_env_headers' from 'opentelemetry.util.re' (/usr/local/lib/python3.9/site-packages/opentelemetry/util/re.py)` error in version `1.13.0`.