### PR TITLE
feat: Add fastapi-users support

### DIFF
--- a/fastapi_template/cli.py
+++ b/fastapi_template/cli.py
@@ -34,7 +34,7 @@ def db_menu_update_info(ctx: BuilderContext, menu: SingularMenuModel) -> Builder
     return ctx
 
 
-def disable_orm(ctx: BuilderContext) -> MenuEntry:
+def disable_orm(ctx: BuilderContext) -> Optional[MenuEntry]:
     if ctx.db == "none":
         ctx.orm = "none"
         return SKIP_ENTRY
@@ -74,7 +74,8 @@ api_menu = SingularMenuModel(
                 "Choose this option if you want to create a service with {name}.\n"
                 "It's more suitable for {generic} web-services or services without databases.".format(
                     name=colored("REST API", color="green"),
-                    generic=colored("generic", color="cyan", attrs=["underline"]),
+                    generic=colored("generic", color="cyan",
+                                    attrs=["underline"]),
                 )
             ),
         ),
@@ -145,7 +146,8 @@ db_menu = SingularMenuModel(
                 "{name} is the most popular database made by oracle.\n"
                 "It's a good fit for {prod} application.".format(
                     name=colored("MySQL", color="green"),
-                    prod=colored("production-grade", color="cyan", attrs=["underline"]),
+                    prod=colored("production-grade", color="cyan",
+                                 attrs=["underline"]),
                 )
             ),
             additional_info=Database(
@@ -164,7 +166,8 @@ db_menu = SingularMenuModel(
                 "{name} is second most popular open-source relational database.\n"
                 "It's a good fit for {prod} application.".format(
                     name=colored("PostgreSQL", color="green"),
-                    prod=colored("production-grade", color="cyan", attrs=["underline"]),
+                    prod=colored("production-grade", color="cyan",
+                                 attrs=["underline"]),
                 )
             ),
             additional_info=Database(
@@ -239,7 +242,8 @@ orm_menu = SingularMenuModel(
                 "If you select this option, you will get only {what}.\n"
                 "The rest {warn}.".format(
                     what=colored("raw database", color="green"),
-                    warn=colored("is up to you", color="red", attrs=["underline"]),
+                    warn=colored("is up to you", color="red",
+                                 attrs=["underline"]),
                 )
             ),
         ),
@@ -330,7 +334,24 @@ features_menu = MultiselectMenuModel(
                         color="green",
                     ),
                     purpose1=colored("caching", color="cyan"),
-                    purpose2=colored("storing temporary variables", color="cyan"),
+                    purpose2=colored(
+                        "storing temporary variables", color="cyan"),
+                )
+            ),
+        ),
+        MenuEntry(
+            code="add_users",
+            cli_name="add_users",
+            user_view="Add users support with fastapi-users",
+            description=(
+                "{name}.\n"
+                "Adds {purpose1} JWT, cookie and OAuth endpoints and {purpose2} models CRUD's. Only supports SQLAlchemy.".format(
+                    name=colored(
+                        "Add fastapi-users",
+                        color="green",
+                    ),
+                    purpose1=colored("authentication", color="red"),
+                    purpose2=colored("user", color="cyan"),
                 )
             ),
         ),
@@ -383,7 +404,8 @@ features_menu = MultiselectMenuModel(
                 "This option will add {what} manifests to your project.\n"
                 "But this option is {warn}, since if you want to use k8s, please create helm.".format(
                     what=colored("kubernetes", color="green"),
-                    warn=colored("deprecated", color="red", attrs=["underline"]),
+                    warn=colored("deprecated", color="red",
+                                 attrs=["underline"]),
                 )
             ),
         ),

--- a/fastapi_template/cli.py
+++ b/fastapi_template/cli.py
@@ -47,6 +47,12 @@ def do_not_ask_features_if_quite(ctx: BuilderContext) -> Optional[List[MenuEntry
     return None
 
 
+def do_not_ask_features_if_no_users(ctx: BuilderContext) -> Optional[list[MenuEntry]]:
+    if not ctx.add_users:
+        return [SKIP_ENTRY]
+    return None
+
+
 def check_db(allowed_values: List[str]) -> Callable[[BuilderContext], bool]:
     def checker(ctx: BuilderContext) -> bool:
         return ctx.db not in allowed_values
@@ -342,15 +348,16 @@ features_menu = MultiselectMenuModel(
         MenuEntry(
             code="add_users",
             cli_name="add_users",
-            user_view="Add users support with fastapi-users",
+            user_view="Add fastapi-users support",
+            is_hidden=check_orm(["sqlalchemy"]),
             description=(
-                "{name}.\n"
-                "Adds {purpose1} JWT, cookie and OAuth endpoints and {purpose2} models CRUD's. Only supports SQLAlchemy.".format(
+                "{name} is a user management extension.\n"
+                "Adds {purpose1} JWT or cookie endpoints and {purpose2} models CRUD's.".format(
                     name=colored(
-                        "Add fastapi-users",
-                        color="green",
+                        "Fastapi-users",
+                        color="cyan",
                     ),
-                    purpose1=colored("authentication", color="red"),
+                    purpose1=colored("authentication", color="cyan"),
                     purpose2=colored("user", color="cyan"),
                 )
             ),
@@ -556,6 +563,42 @@ features_menu = MultiselectMenuModel(
     ],
 )
 
+users_backend_menu = MultiselectMenuModel(
+    title="FastApi Users Backend",
+    code="users_menu",
+    description="Available backends for authentication with fastapi_users",
+    multiselect=True,
+    before_ask=do_not_ask_features_if_no_users,
+    entries=[
+        MenuEntry(
+            code="cookie_auth",
+            cli_name="cookie auth",
+            user_view="Add authentication via cookie support",
+            description=(
+                "Adds {cookie} authentication support.".format(
+                    cookie=colored(
+                        "cookie",
+                        color="green",
+                    )
+                )
+            ),
+        ),
+        MenuEntry(
+            code="jwt_auth",
+            cli_name="jwt auth",
+            user_view="Add JWT auth support",
+            description=(
+                "Adds {name} authentication support.".format(
+                    name=colored(
+                        "JWT",
+                        color="green",
+                    )
+                )
+            ),
+        ),
+    ],
+)
+
 
 def handle_cli(
     menus: List[BaseMenuModel],
@@ -597,6 +640,7 @@ def run_command(callback: Callable[[BuilderContext], None]) -> None:
         orm_menu,
         ci_menu,
         features_menu,
+        users_backend_menu,
     ]
 
     cmd = Command(

--- a/fastapi_template/template/cookiecutter.json
+++ b/fastapi_template/template/cookiecutter.json
@@ -65,6 +65,9 @@
     "gunicorn": {
         "type": "bool"
     },
+    "add_users": {
+        "type": "bool"
+    },
     "_extensions": [
         "cookiecutter.extensions.RandomStringExtension"
     ],

--- a/fastapi_template/template/cookiecutter.json
+++ b/fastapi_template/template/cookiecutter.json
@@ -68,6 +68,12 @@
     "add_users": {
         "type": "bool"
     },
+    "cookie_auth": {
+        "type": "bool"
+    },
+    "jwt_auth": {
+        "type": "bool"
+    },
     "_extensions": [
         "cookiecutter.extensions.RandomStringExtension"
     ],

--- a/fastapi_template/template/{{cookiecutter.project_name}}/.env
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/.env
@@ -4,3 +4,8 @@
 {%- elif cookiecutter.db_info.name != 'none' %}
 {{cookiecutter.project_name | upper}}_DB_HOST=localhost
 {%- endif %}
+{%- if cookiecutter.add_users == "True" %}
+GOOGLE_OAUTH_CLIENT_ID=""
+GOOGLE_OAUTH_CLIENT_SECRET=""
+USERS_SECRET=""
+{%- endif %}

--- a/fastapi_template/template/{{cookiecutter.project_name}}/.env
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/.env
@@ -5,7 +5,5 @@
 {{cookiecutter.project_name | upper}}_DB_HOST=localhost
 {%- endif %}
 {%- if cookiecutter.add_users == "True" %}
-GOOGLE_OAUTH_CLIENT_ID=""
-GOOGLE_OAUTH_CLIENT_SECRET=""
 USERS_SECRET=""
 {%- endif %}

--- a/fastapi_template/template/{{cookiecutter.project_name}}/conditional_files.json
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/conditional_files.json
@@ -120,6 +120,13 @@
             "{{cookiecutter.project_name}}/tests/test_rabbit.py"
         ]
     },
+    "Users model": {
+        "enabled": "{{cookiecutter.add_users}}",
+        "resources": [
+            "{{cookiecutter.project_name}}/web/api/users",
+            "{{cookiecutter.project_name}}/db_sa/models/users.py"
+        ]
+    },
     "Dummy model": {
         "enabled": "{{cookiecutter.add_dummy}}",
         "resources": [

--- a/fastapi_template/template/{{cookiecutter.project_name}}/pyproject.toml
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/pyproject.toml
@@ -19,9 +19,9 @@ gunicorn = "^21.2.0"
 {%- endif %}
 {%- if cookiecutter.add_users == "True" %}
 {%- if cookiecutter.orm == "sqlalchemy" %}
-fastapi-users = "^10.2.1"
+fastapi-users = "^12.1.2"
 httpx-oauth = "^0.10.2"
-fastapi-users-db-sqlalchemy = "^4.0.3"
+fastapi-users-db-sqlalchemy = "^6.0.1"
 {%- endif %}
 {%- endif %}
 {%- if cookiecutter.pydanticv1 == "True" %}

--- a/fastapi_template/template/{{cookiecutter.project_name}}/pyproject.toml
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/pyproject.toml
@@ -17,6 +17,13 @@ uvicorn = { version = "^0.22.0", extras = ["standard"] }
 {%- if cookiecutter.gunicorn == "True" %}
 gunicorn = "^21.2.0"
 {%- endif %}
+{%- if cookiecutter.add_users == "True" %}
+{%- if cookiecutter.orm == "sqlalchemy" %}
+fastapi-users = "^10.2.1"
+httpx-oauth = "^0.10.2"
+fastapi-users-db-sqlalchemy = "^4.0.3"
+{%- endif %}
+{%- endif %}
 {%- if cookiecutter.pydanticv1 == "True" %}
 pydantic = { version = "^1", extras=["dotenv"] }
 {%- else %}

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/db_sa/models/users.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/db_sa/models/users.py
@@ -1,0 +1,84 @@
+import uuid
+from typing import Optional
+
+from fastapi import Depends, Request
+from fastapi_users import BaseUserManager, FastAPIUsers, UUIDIDMixin, schemas
+from fastapi_users.authentication import (AuthenticationBackend, BearerTransport,
+                                          CookieTransport, JWTStrategy)
+from fastapi_users.db import SQLAlchemyBaseUserTableUUID, SQLAlchemyUserDatabase
+from httpx_oauth.clients.google import GoogleOAuth2
+from sqlalchemy.ext.asyncio import AsyncSession
+from {{cookiecutter.project_name}}.db.base import Base
+from {{cookiecutter.project_name}}.db.dependencies import get_db_session
+from {{cookiecutter.project_name}}.settings import settings
+
+SECRET = settings.users_secret
+
+
+class User(SQLAlchemyBaseUserTableUUID, Base):
+    pass
+
+
+class UserRead(schemas.BaseUser[uuid.UUID]):
+    pass
+
+
+class UserCreate(schemas.BaseUserCreate):
+    pass
+
+
+class UserUpdate(schemas.BaseUserUpdate):
+    pass
+
+
+class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
+    reset_password_token_secret = SECRET
+    verification_token_secret = SECRET
+
+    async def on_after_register(self, user: User, request: Optional[Request] = None):
+        print(f"User {user.id} has registered.")
+
+    async def on_after_forgot_password(
+        self, user: User, token: str, request: Optional[Request] = None
+    ):
+        print(f"User {user.id} has forgot their password. Reset token: {token}")
+
+    async def on_after_request_verify(
+        self, user: User, token: str, request: Optional[Request] = None
+    ):
+        print(f"Verification requested for user {user.id}. Verification token: {token}")
+
+
+async def get_user_db(session: AsyncSession = Depends(get_db_session)):
+    yield SQLAlchemyUserDatabase(session, User)
+
+
+async def get_user_manager(user_db: SQLAlchemyUserDatabase = Depends(get_user_db)):
+    yield UserManager(user_db)
+
+    
+def get_jwt_strategy() -> JWTStrategy:
+    return JWTStrategy(secret=SECRET, lifetime_seconds=3600)
+
+
+google_oauth_client = GoogleOAuth2(
+    settings.google_oauth_client_id,
+    settings.google_oauth_client_secret
+)
+
+bearer_transport = BearerTransport(tokenUrl="auth/jwt/login")
+cookie_transport = CookieTransport(cookie_max_age=3600)
+
+auth_backend = AuthenticationBackend(
+    name="jwt",
+    transport=bearer_transport,
+    get_strategy=get_jwt_strategy,
+)
+
+auth_cookie = AuthenticationBackend(
+    name="cookie", transport=cookie_transport, get_strategy=get_jwt_strategy
+)
+
+api_users = FastAPIUsers[User, uuid.UUID](get_user_manager, [auth_backend, auth_cookie])
+
+current_active_user = api_users.current_user(active=True)

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/db_sa/models/users.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/db_sa/models/users.py
@@ -1,49 +1,72 @@
+# type: ignore
 import uuid
-from typing import Optional
 
-from fastapi import Depends, Request
+from fastapi import Depends
 from fastapi_users import BaseUserManager, FastAPIUsers, UUIDIDMixin, schemas
-from fastapi_users.authentication import (AuthenticationBackend, BearerTransport,
-                                          CookieTransport, JWTStrategy)
-from fastapi_users.db import SQLAlchemyBaseUserTableUUID, SQLAlchemyUserDatabase
+from fastapi_users.authentication import (
+    AuthenticationBackend,
+    BearerTransport,
 
+    CookieTransport,
+    JWTStrategy,
+)
+from fastapi_users.db import SQLAlchemyBaseUserTableUUID, SQLAlchemyUserDatabase
 from sqlalchemy.ext.asyncio import AsyncSession
+
 from {{cookiecutter.project_name}}.db.base import Base
 from {{cookiecutter.project_name}}.db.dependencies import get_db_session
 from {{cookiecutter.project_name}}.settings import settings
 
 
 class User(SQLAlchemyBaseUserTableUUID, Base):
-    pass
+    """Represents a user entity."""
 
 
 class UserRead(schemas.BaseUser[uuid.UUID]):
-    pass
+    """Represents a read command for a user."""
 
 
 class UserCreate(schemas.BaseUserCreate):
-    pass
+    """Represents a create command for a user."""
 
 
 class UserUpdate(schemas.BaseUserUpdate):
-    pass
+    """Represents an update command for a user."""
 
 
 class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
+    """Manages a user session and its tokens."""
     reset_password_token_secret = settings.users_secret
     verification_token_secret = settings.users_secret
 
 
-async def get_user_db(session: AsyncSession = Depends(get_db_session)):
+async def get_user_db(session: AsyncSession = Depends(get_db_session)) -> SQLAlchemyUserDatabase:
+    """
+    Yield a SQLAlchemyUserDatabase instance.
+
+    :param session: asynchronous SQLAlchemy session.
+    :yields: instance of SQLAlchemyUserDatabase.
+    """
     yield SQLAlchemyUserDatabase(session, User)
 
 
-async def get_user_manager(user_db: SQLAlchemyUserDatabase = Depends(get_user_db)):
+async def get_user_manager(user_db: SQLAlchemyUserDatabase = Depends(get_user_db)) -> UserManager:
+    """
+    Yield a UserManager instance.
+
+    :param user_db: SQLAlchemy user db instance
+    :yields: an instance of UserManager.
+    """
     yield UserManager(user_db)
 
-    
+
 def get_jwt_strategy() -> JWTStrategy:
-    return JWTStrategy(secret=settings.users_secret, lifetime_seconds=3600)
+    """
+    Return a JWTStrategy in order to instantiate it dynamically.
+
+    :returns: instance of JWTStrategy with provided settings.
+    """
+    return JWTStrategy(secret=settings.users_secret, lifetime_seconds=None)
 
 
 {%- if cookiecutter.jwt_auth == "True" %}
@@ -56,15 +79,19 @@ auth_jwt = AuthenticationBackend(
 {%- endif %}
 
 {%- if cookiecutter.cookie_auth == "True" %}
-cookie_transport = CookieTransport(cookie_max_age=3600)
+cookie_transport = CookieTransport()
 auth_cookie = AuthenticationBackend(
     name="cookie", transport=cookie_transport, get_strategy=get_jwt_strategy
 )
 {%- endif %}
 
 backends = [
-    {%- if cookiecutter.cookie_auth == "True" %}auth_cookie,{%- endif %}
-    {%- if cookiecutter.jwt_auth == "True" %}auth_jwt,{%- endif %}
+    {%- if cookiecutter.cookie_auth == "True" %}
+    auth_cookie,
+    {%- endif %}
+    {%- if cookiecutter.jwt_auth == "True" %}
+    auth_jwt,
+    {%- endif %}
 ]
 
 api_users = FastAPIUsers[User, uuid.UUID](get_user_manager, backends)

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/db_sa/models/users.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/db_sa/models/users.py
@@ -6,13 +6,11 @@ from fastapi_users import BaseUserManager, FastAPIUsers, UUIDIDMixin, schemas
 from fastapi_users.authentication import (AuthenticationBackend, BearerTransport,
                                           CookieTransport, JWTStrategy)
 from fastapi_users.db import SQLAlchemyBaseUserTableUUID, SQLAlchemyUserDatabase
-from httpx_oauth.clients.google import GoogleOAuth2
+
 from sqlalchemy.ext.asyncio import AsyncSession
 from {{cookiecutter.project_name}}.db.base import Base
 from {{cookiecutter.project_name}}.db.dependencies import get_db_session
 from {{cookiecutter.project_name}}.settings import settings
-
-SECRET = settings.users_secret
 
 
 class User(SQLAlchemyBaseUserTableUUID, Base):
@@ -32,21 +30,8 @@ class UserUpdate(schemas.BaseUserUpdate):
 
 
 class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
-    reset_password_token_secret = SECRET
-    verification_token_secret = SECRET
-
-    async def on_after_register(self, user: User, request: Optional[Request] = None):
-        print(f"User {user.id} has registered.")
-
-    async def on_after_forgot_password(
-        self, user: User, token: str, request: Optional[Request] = None
-    ):
-        print(f"User {user.id} has forgot their password. Reset token: {token}")
-
-    async def on_after_request_verify(
-        self, user: User, token: str, request: Optional[Request] = None
-    ):
-        print(f"Verification requested for user {user.id}. Verification token: {token}")
+    reset_password_token_secret = settings.users_secret
+    verification_token_secret = settings.users_secret
 
 
 async def get_user_db(session: AsyncSession = Depends(get_db_session)):
@@ -58,27 +43,30 @@ async def get_user_manager(user_db: SQLAlchemyUserDatabase = Depends(get_user_db
 
     
 def get_jwt_strategy() -> JWTStrategy:
-    return JWTStrategy(secret=SECRET, lifetime_seconds=3600)
+    return JWTStrategy(secret=settings.users_secret, lifetime_seconds=3600)
 
 
-google_oauth_client = GoogleOAuth2(
-    settings.google_oauth_client_id,
-    settings.google_oauth_client_secret
-)
-
+{%- if cookiecutter.jwt_auth == "True" %}
 bearer_transport = BearerTransport(tokenUrl="auth/jwt/login")
-cookie_transport = CookieTransport(cookie_max_age=3600)
-
-auth_backend = AuthenticationBackend(
+auth_jwt = AuthenticationBackend(
     name="jwt",
     transport=bearer_transport,
     get_strategy=get_jwt_strategy,
 )
+{%- endif %}
 
+{%- if cookiecutter.cookie_auth == "True" %}
+cookie_transport = CookieTransport(cookie_max_age=3600)
 auth_cookie = AuthenticationBackend(
     name="cookie", transport=cookie_transport, get_strategy=get_jwt_strategy
 )
+{%- endif %}
 
-api_users = FastAPIUsers[User, uuid.UUID](get_user_manager, [auth_backend, auth_cookie])
+backends = [
+    {%- if cookiecutter.cookie_auth == "True" %}auth_cookie,{%- endif %}
+    {%- if cookiecutter.jwt_auth == "True" %}auth_jwt,{%- endif %}
+]
+
+api_users = FastAPIUsers[User, uuid.UUID](get_user_manager, backends)
 
 current_active_user = api_users.current_user(active=True)

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/settings.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/settings.py
@@ -49,7 +49,7 @@ class Settings(BaseSettings):
 
     {%- if cookiecutter.add_users == "True" %}
     {%- if cookiecutter.orm == "sqlalchemy" %}
-    users_secret = os.getenv("USERS_SECRET", "")
+    users_secret: str = os.getenv("USERS_SECRET", "")
     {%- endif %}
     {%- endif %}
     {% if cookiecutter.db_info.name != "none" -%}

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/settings.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/settings.py
@@ -50,8 +50,6 @@ class Settings(BaseSettings):
     {%- if cookiecutter.add_users == "True" %}
     {%- if cookiecutter.orm == "sqlalchemy" %}
     users_secret = os.getenv("USERS_SECRET", "")
-    google_oauth_client_id = os.getenv("GOOGLE_OAUTH_CLIENT_ID", "")
-    google_oauth_client_secret = os.getenv("GOOGLE_OAUTH_CLIENT_SECRET", "")
     {%- endif %}
     {%- endif %}
     {% if cookiecutter.db_info.name != "none" -%}

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/settings.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/settings.py
@@ -1,3 +1,4 @@
+import os
 import enum
 from pathlib import Path
 from tempfile import gettempdir
@@ -43,9 +44,16 @@ class Settings(BaseSettings):
 
     # Current environment
     environment: str = "dev"
-
+    
     log_level: LogLevel = LogLevel.INFO
 
+    {%- if cookiecutter.add_users == "True" %}
+    {%- if cookiecutter.orm == "sqlalchemy" %}
+    users_secret = os.getenv("USERS_SECRET", "")
+    google_oauth_client_id = os.getenv("GOOGLE_OAUTH_CLIENT_ID", "")
+    google_oauth_client_secret = os.getenv("GOOGLE_OAUTH_CLIENT_SECRET", "")
+    {%- endif %}
+    {%- endif %}
     {% if cookiecutter.db_info.name != "none" -%}
 
     # Variables for the database

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/router.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/router.py
@@ -46,8 +46,6 @@ api_router.include_router(echo.router, prefix="/echo", tags=["echo"])
 {%- if cookiecutter.add_dummy == 'True' %}
 api_router.include_router(dummy.router, prefix="/dummy", tags=["dummy"])
 {%- endif %}
-
-
 {%- if cookiecutter.enable_redis == "True" %}
 api_router.include_router(redis.router, prefix="/redis", tags=["redis"])
 {%- endif %}

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/router.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/router.py
@@ -8,6 +8,10 @@ from {{cookiecutter.project_name}}.web.api import echo
 from {{cookiecutter.project_name}}.web.api import dummy
 
 {%- endif %}
+{%- if cookiecutter.add_users == 'True' %}
+from {{cookiecutter.project_name}}.web.api import users
+from {{cookiecutter.project_name}}.db.models.users import api_users
+{%- endif %}
 {%- if cookiecutter.enable_redis == "True" %}
 from {{cookiecutter.project_name}}.web.api import redis
 
@@ -39,6 +43,11 @@ api_router.include_router(echo.router, prefix="/echo", tags=["echo"])
 {%- if cookiecutter.add_dummy == 'True' %}
 api_router.include_router(dummy.router, prefix="/dummy", tags=["dummy"])
 {%- endif %}
+
+{%- if cookiecutter.add_users == 'True' %}
+api_router.include_router(users.router)
+{%- endif %}
+
 {%- if cookiecutter.enable_redis == "True" %}
 api_router.include_router(redis.router, prefix="/redis", tags=["redis"])
 {%- endif %}

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/router.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/router.py
@@ -1,5 +1,9 @@
 from fastapi.routing import APIRouter
 
+{%- if cookiecutter.add_users == 'True' %}
+from {{cookiecutter.project_name}}.web.api import users
+from {{cookiecutter.project_name}}.db.models.users import api_users
+{%- endif %}
 {%- if cookiecutter.enable_routers == "True" %}
 {%- if cookiecutter.api_type == 'rest' %}
 from {{cookiecutter.project_name}}.web.api import echo
@@ -7,10 +11,6 @@ from {{cookiecutter.project_name}}.web.api import echo
 {%- if cookiecutter.add_dummy == 'True' %}
 from {{cookiecutter.project_name}}.web.api import dummy
 
-{%- endif %}
-{%- if cookiecutter.add_users == 'True' %}
-from {{cookiecutter.project_name}}.web.api import users
-from {{cookiecutter.project_name}}.db.models.users import api_users
 {%- endif %}
 {%- if cookiecutter.enable_redis == "True" %}
 from {{cookiecutter.project_name}}.web.api import redis
@@ -34,6 +34,9 @@ from {{cookiecutter.project_name}}.web.api import monitoring
 
 api_router = APIRouter()
 api_router.include_router(monitoring.router)
+{%- if cookiecutter.add_users == 'True' %}
+api_router.include_router(users.router)
+{%- endif %}
 {%- if cookiecutter.self_hosted_swagger == "True" %}
 api_router.include_router(docs.router)
 {%- endif %}
@@ -44,9 +47,6 @@ api_router.include_router(echo.router, prefix="/echo", tags=["echo"])
 api_router.include_router(dummy.router, prefix="/dummy", tags=["dummy"])
 {%- endif %}
 
-{%- if cookiecutter.add_users == 'True' %}
-api_router.include_router(users.router)
-{%- endif %}
 
 {%- if cookiecutter.enable_redis == "True" %}
 api_router.include_router(redis.router, prefix="/redis", tags=["redis"])

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/users/__init__.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/users/__init__.py
@@ -1,0 +1,4 @@
+"""API for checking project status."""
+from {{cookiecutter.project_name}}.web.api.users.views import router
+
+__all__ = ["router"]

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/users/views.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/users/views.py
@@ -1,0 +1,47 @@
+from fastapi import APIRouter
+
+from {{cookiecutter.project_name}}.db.models.users import (UserCreate,
+                                                           UserRead,
+                                                           UserUpdate,
+                                                           api_users,
+                                                           auth_backend,
+                                                           auth_cookie)
+
+
+router = APIRouter()
+
+router.include_router(
+    api_users.get_register_router(UserRead, UserCreate),
+    prefix="/auth",
+    tags=["auth"],
+)
+
+router.include_router(
+    api_users.get_reset_password_router(),
+    prefix="/auth",
+    tags=["auth"],
+)
+
+router.include_router(
+    api_users.get_verify_router(UserRead),
+    prefix="/auth",
+    tags=["auth"],
+)
+
+router.include_router(
+    api_users.get_users_router(UserRead, UserUpdate),
+    prefix="/users",
+    tags=["users"],
+)
+
+router.include_router(
+    api_users.get_auth_router(auth_backend),
+    prefix="/auth/jwt",
+    tags=["auth"]
+)
+
+router.include_router(
+    api_users.get_auth_router(auth_cookie),
+    prefix="/auth/cookie",
+    tags=["auth"]
+)

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/users/views.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/users/views.py
@@ -4,7 +4,7 @@ from {{cookiecutter.project_name}}.db.models.users import (UserCreate,
                                                            UserRead,
                                                            UserUpdate,
                                                            api_users,
-                                                           auth_backend,
+                                                           auth_jwt,
                                                            auth_cookie)
 
 
@@ -33,15 +33,18 @@ router.include_router(
     prefix="/users",
     tags=["users"],
 )
-
+{%- if cookiecutter.jwt_auth == "True" %}
 router.include_router(
-    api_users.get_auth_router(auth_backend),
+    api_users.get_auth_router(auth_jwt),
     prefix="/auth/jwt",
     tags=["auth"]
 )
+{%- endif %}
 
+{%- if cookiecutter.cookie_auth == "True" %}
 router.include_router(
     api_users.get_auth_router(auth_cookie),
     prefix="/auth/cookie",
     tags=["auth"]
 )
+{%- endif %}

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/users/views.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/users/views.py
@@ -1,11 +1,13 @@
 from fastapi import APIRouter
 
-from {{cookiecutter.project_name}}.db.models.users import (UserCreate,
-                                                           UserRead,
-                                                           UserUpdate,
-                                                           api_users,
-                                                           auth_jwt,
-                                                           auth_cookie)
+from {{cookiecutter.project_name}}.db.models.users import (
+    UserCreate,  # type: ignore
+    UserRead,  # type: ignore
+    UserUpdate,  # type: ignore
+    api_users,  # type: ignore
+    auth_jwt,  # type: ignore
+    auth_cookie,  # type: ignore
+)
 
 
 router = APIRouter()

--- a/fastapi_template/tests/conftest.py
+++ b/fastapi_template/tests/conftest.py
@@ -9,6 +9,7 @@ from faker import Faker
 from fastapi_template.input_model import BuilderContext, Database
 from fastapi_template.tests.utils import run_docker_compose_command, model_dump_compat
 
+
 @pytest.fixture
 def project_name(worker_id: str) -> str:
     """
@@ -58,6 +59,7 @@ def default_context(project_name: str) -> None:
         db_info=model_dump_compat(Database(name="none")),
         enable_redis=False,
         enable_taskiq=False,
+        add_users=False,
         enable_migrations=False,
         enable_kube=False,
         enable_routers=True,


### PR DESCRIPTION
Adds support to fastapi-users by adding the option to the menu and creating views for JWT, cookie and OAuth authentication. Adds user models and views. This is only compatible with SQLAlchemy.

Tested locally and users can be registered and log in works.

![register2](https://user-images.githubusercontent.com/26823162/212477353-0eea85e1-0ce9-4d37-9a36-20cf59ce5deb.png)
![login](https://user-images.githubusercontent.com/26823162/212477359-5b2eae49-4030-481a-82c2-8cce9f8749d6.png)
![user](https://user-images.githubusercontent.com/26823162/212477376-5781d9b7-b05c-441d-9ed2-053326c38cc4.png)
