### PR TITLE
Fixes GitLab CI/CD configuration compatibility with GitLab 15.

### DIFF
--- a/fastapi_template/template/{{cookiecutter.project_name}}/.gitlab-ci.yml
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/.gitlab-ci.yml
@@ -104,5 +104,8 @@ pytest:
   artifacts:
     when: always
     reports:
-      cobertura: coverage.xml
       junit: report.xml
+      coverage_report:
+        coverage_format: cobertura
+        path: coverage.xml
+


### PR DESCRIPTION
Cobertura keyword causes error in GitLab >= 15.0:
https://gitlab.com/gitlab-org/gitlab/-/issues/344533/