### PR TITLE
Fixes ncurses problem and reduces image size.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
-FROM python:3.9.7-alpine3.13
+FROM python:3.9.7-alpine3.13 AS builder
 
 RUN apk add --no-cache \
-  curl \
   # For building dependencies. \
   gcc \
   musl-dev \
-  git \
   g++ \
   libffi-dev \
   # For psycopg \
@@ -13,27 +11,33 @@ RUN apk add --no-cache \
   # For mysql deps \
   mariadb-connector-c-dev
 
+COPY pyproject.toml poetry.lock README.md /src/
+COPY ./fastapi_template /src/fastapi_template/
+WORKDIR /src
+
+RUN python -m venv --copies /src/venv
+RUN /src/venv/bin/pip install poetry==1.4.2
+RUN --mount=type=cache,target=/root/.cache/pypoetry \
+    . /src/venv/bin/activate && poetry install
+
+FROM python:3.9.7-alpine3.13
+
+RUN apk add --no-cache git ncurses
 RUN adduser --disabled-password fastapi_template
 RUN mkdir /projects /src
 RUN chown -R fastapi_template:fastapi_template /projects /src
 USER fastapi_template
 
+COPY --from=builder /src/venv /src/venv/
+COPY ./fastapi_template /src/fastapi_template/
 WORKDIR /src
 
-ENV PATH ${PATH}:/home/fastapi_template/.local/bin
+ENV PATH ${PATH}:/src/venv/bin
 
-RUN pip install poetry==1.4.2
-
-COPY . /src/
-RUN pip install .
-
-USER root
-RUN rm -rfv /src
-RUN apk del curl
 USER fastapi_template
 
 VOLUME /projects
 WORKDIR /projects
 
-ENTRYPOINT ["/home/fastapi_template/.local/bin/fastapi_template"]
+ENTRYPOINT ["/src/venv/bin/fastapi_template"]
 


### PR DESCRIPTION
Running FastAPI-template from docker fails because simple-term-menu requires `tput` utility from ncurses.

Also, changed Dockerfile to use two stages build, reducing the size by 3.7 times (157 Mb vs 595 Mb).