### PR TITLE
fix: update deprecated usage of taskiq_redis broker

### DIFF
--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/tkq.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/tkq.py
@@ -21,8 +21,7 @@ result_backend = RedisAsyncResultBackend(
 {%- if cookiecutter.enable_rmq == "True" %}
 broker = AioPikaBroker(
     str(settings.rabbit_url),
-    {%- if cookiecutter.enable_redis == "True" %}result_backend=result_backend, {%- endif %}
-)
+){%- if cookiecutter.enable_redis == "True" %}.with_result_backend(result_backend){%- endif %}
 {%- elif cookiecutter.enable_redis == "True" %}
 broker = ListQueueBroker(
     str(settings.redis_url.with_path("/1")),

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/tkq.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/tkq.py
@@ -26,8 +26,7 @@ broker = AioPikaBroker(
 {%- elif cookiecutter.enable_redis == "True" %}
 broker = ListQueueBroker(
     str(settings.redis_url.with_path("/1")),
-    result_backend=result_backend,
-)
+).with_result_backend(result_backend)
 {%- else %}
 broker = ZeroMQBroker()
 {%- endif %}


### PR DESCRIPTION
See <https://github.com/taskiq-python/taskiq/commit/2c28eefaa1a13c45afd409c9bc29a1ada50cce14>.

Not sure if the code is the best practice, please review & edit.