### PR TITLE
Fixed dummy model. 

### DIFF
--- a/fastapi_template/cli.py
+++ b/fastapi_template/cli.py
@@ -380,6 +380,7 @@ features_menu = MultiselectMenuModel(
             code="add_dummy",
             cli_name="dummy",
             user_view="Add dummy model",
+            is_hidden=lambda ctx: ctx.orm == "none",
             description=(
                 "This option creates {what} as an example of how to use chosen ORM.\n"
                 "Also this option will generate you an example of {dao}.".format(


### PR DESCRIPTION
This PR closes #173. 

Now option is hidden from users, when they choose no database or orm. Unfortunately, users still able to add `--dummy` with none orm using CLI. 