### PR TITLE
feature: MongoDB support via beanie

### DIFF
--- a/fastapi_template/cli.py
+++ b/fastapi_template/cli.py
@@ -176,6 +176,23 @@ db_menu = SingularMenuModel(
                 port=5432,
             ),
         ),
+        MenuEntry(
+            code="mongodb",
+            user_view="MongoDB",
+            description=(
+                "{name} is one of the most popular NoSQL databases out there.".format(
+                    name=colored("MongoDB", color="green"),
+                )
+            ),
+            additional_info=Database(
+                name="mongodb",
+                image="mongo:4.2",
+                async_driver="beanie",
+                driver_short="pymongo",
+                driver="pymongo",
+                port=27017
+            ),
+        )
     ],
 )
 
@@ -234,7 +251,7 @@ orm_menu = SingularMenuModel(
     entries=[
         MenuEntry(
             code="none",
-            user_view="Whithout ORMs",
+            user_view="Without ORMs",
             description=(
                 "If you select this option, you will get only {what}.\n"
                 "The rest {warn}.".format(
@@ -246,6 +263,7 @@ orm_menu = SingularMenuModel(
         MenuEntry(
             code="ormar",
             user_view="Ormar",
+            is_hidden=check_db(["sqlite", "mysql", "postgresql"]),
             pydantic_v1=True,
             description=(
                 "{what} is a great {feature} ORM.\n"
@@ -258,6 +276,7 @@ orm_menu = SingularMenuModel(
         MenuEntry(
             code="sqlalchemy",
             user_view="SQLAlchemy",
+            is_hidden=check_db(["sqlite", "mysql", "postgresql"]),
             description=(
                 "{what} is the most popular python ORM.\n"
                 "It has a {feature} and a big community around it.".format(
@@ -269,6 +288,7 @@ orm_menu = SingularMenuModel(
         MenuEntry(
             code="tortoise",
             user_view="Tortoise",
+            is_hidden=check_db(["sqlite", "mysql", "postgresql"]),
             description=(
                 "{what} is a great {feature} ORM.\n"
                 "It's easy to use, it has it's own migration tooling.".format(
@@ -302,6 +322,18 @@ orm_menu = SingularMenuModel(
                 )
             ),
         ),
+        MenuEntry(
+            code="beanie",
+            user_view="Beanie",
+            is_hidden=check_db(["mongodb"]),
+            description=(
+                "{what} is an asynchronous object-document mapper (ODM) for MongoDB.\n"
+                "Data models are based on Pydantic.".format(
+                    what=colored("Beanie", color="green"),
+                )
+            ),
+        ),
+
     ],
 )
 

--- a/fastapi_template/template/{{cookiecutter.project_name}}/README.md
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/README.md
@@ -51,7 +51,9 @@ $ tree "{{cookiecutter.project_name}}"
 ├── conftest.py  # Fixtures for all tests. 
 {%- if cookiecutter.db_info.name != "none" %}
 ├── db  # module contains db configurations
+{%- if cookiecutter.db_info.name != "mongodb" %}
 │   ├── dao  # Data Access Objects. Contains different classes to interact with database.
+{%- endif %}
 │   └── models  # Package contains different models for ORMs.
 {%- endif %}
 ├── __main__.py  # Startup script. Starts uvicorn.
@@ -129,6 +131,15 @@ By default it runs:
 
 
 You can read more about pre-commit here: https://pre-commit.com/
+
+{%- if cookiecutter.db_info.name == 'mongodb' %}
+## MongoDB
+
+Start a MongoDB container via docker compose by:
+```shell
+docker-compose -f deploy/docker-compose.yml --project-directory . up -d db
+```
+{%- endif %}
 
 {%- if cookiecutter.enable_kube == 'True' %}
 

--- a/fastapi_template/template/{{cookiecutter.project_name}}/conditional_files.json
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/conditional_files.json
@@ -62,7 +62,7 @@
         ]
     },
     "Postgres and MySQL support": {
-        "enabled": "{{cookiecutter.db_info.name != 'sqlite'}}",
+        "enabled": "{{cookiecutter.db_info.name not in ['sqlite', 'mongodb']}}",
         "resources": [
             "deploy/kube/db.yml"
         ]
@@ -136,6 +136,7 @@
             "{{cookiecutter.project_name}}/tests/test_dummy.py",
             "{{cookiecutter.project_name}}/db_piccolo/dao",
             "{{cookiecutter.project_name}}/db_piccolo/models/dummy_model.py",
+            "{{cookiecutter.project_name}}/db_beanie/models/dummy_model.py",
             "{{cookiecutter.project_name}}/db_sa/migrations/versions/2021-08-16-16-55_2b7380507a71.py",
             "{{cookiecutter.project_name}}/db_ormar/migrations/versions/2021-08-16-16-55_2b7380507a71.py",
             "{{cookiecutter.project_name}}/db_tortoise/migrations/models/1_20210928165300_init_dummy_pg.sql",
@@ -182,6 +183,12 @@
             "{{cookiecutter.project_name}}/piccolo_conf.py"
         ]
     },
+    "Beanie": {
+        "enabled": "{{cookiecutter.orm == 'beanie'}}",
+        "resources": [
+            "{{cookiecutter.project_name}}/db_beanie"
+        ]
+    }
     "Postgresql DB": {
         "enabled": "{{cookiecutter.db_info.name == 'postgresql'}}",
         "resources": [

--- a/fastapi_template/template/{{cookiecutter.project_name}}/conditional_files.json
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/conditional_files.json
@@ -56,9 +56,20 @@
             "alembic.ini",
             "{{cookiecutter.project_name}}/web/api/dummy",
             "{{cookiecutter.project_name}}/web/gql/dummy",
-            "{{cookiecutter.project_name}}/db_sa",
             "{{cookiecutter.project_name}}/tests/test_dummy.py",
             "deploy/kube/db.yml"
+        ]
+    },
+    "SQLAlchemy support": {
+        "enabled": "{{cookiecutter.db_info.name not in ['none', 'mongodb']}}",
+        "resources": [
+            "{{cookiecutter.project_name}}/db_sa"
+        ]
+    },
+    "Beanie support": {
+        "enabled": "{{cookiecutter.db_info.name == 'mongodb'}}",
+        "resources": [
+            "{{cookiecutter.project_name}}/db_beanie"
         ]
     },
     "Postgres and MySQL support": {
@@ -188,7 +199,7 @@
         "resources": [
             "{{cookiecutter.project_name}}/db_beanie"
         ]
-    }
+    },
     "Postgresql DB": {
         "enabled": "{{cookiecutter.db_info.name == 'postgresql'}}",
         "resources": [

--- a/fastapi_template/template/{{cookiecutter.project_name}}/deploy/docker-compose.dev.yml
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/deploy/docker-compose.dev.yml
@@ -6,6 +6,7 @@ services:
       # Exposes application port.
     - "8000:8000"
     build:
+      context: .
       target: dev
     volumes:
       # Adds current directory as volume.

--- a/fastapi_template/template/{{cookiecutter.project_name}}/deploy/docker-compose.yml
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/deploy/docker-compose.yml
@@ -103,6 +103,18 @@ services:
       retries: 40
   {%- endif %}
 
+  {%- if cookiecutter.db_info.name == "mongodb"%}
+  db:
+    image: {{cookiecutter.db_info.image}}
+    port:
+    - "{{cookiecutter.db_info.port}}:{{cookiecutter.db_info.port}}"
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: "{{cookiecutter.project_name}}"
+      MONGO_INITDB_ROOT_PASSWORD: "{{cookiecutter.project_name}}"
+    command: "mongod"
+  {%- endif %}
+
   {%- if cookiecutter.db_info.name == "mysql" %}
 
   db:

--- a/fastapi_template/template/{{cookiecutter.project_name}}/deploy/docker-compose.yml
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/deploy/docker-compose.yml
@@ -106,7 +106,7 @@ services:
   {%- if cookiecutter.db_info.name == "mongodb"%}
   db:
     image: {{cookiecutter.db_info.image}}
-    port:
+    ports:
     - "{{cookiecutter.db_info.port}}:{{cookiecutter.db_info.port}}"
     restart: always
     environment:

--- a/fastapi_template/template/{{cookiecutter.project_name}}/pyproject.toml
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/pyproject.toml
@@ -86,6 +86,11 @@ aiofiles = "^23.1.0"
 psycopg = { version = "^3.1.9", extras = ["binary", "pool"] }
 {%- endif %}
 httptools = "^0.6.0"
+{%- if cookiecutter.orm == "beanie" %}
+beanie = "^1.21.0"
+{%- else %}
+pymongo = "^4.5.0"
+{%- endif %}
 {%- if cookiecutter.api_type == "graphql" %}
 strawberry-graphql = { version = "^0.194.4", extras = ["fastapi"] }
 {%- endif %}

--- a/fastapi_template/template/{{cookiecutter.project_name}}/replaceable_files.json
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/replaceable_files.json
@@ -4,6 +4,7 @@
         "{{cookiecutter.project_name}}/db_ormar",
         "{{cookiecutter.project_name}}/db_tortoise",
         "{{cookiecutter.project_name}}/db_psycopg",
-        "{{cookiecutter.project_name}}/db_piccolo"
+        "{{cookiecutter.project_name}}/db_piccolo",
+        "{{cookiecutter.project_name}}/db_beanie"
     ]
 }

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/db_beanie/models/__init__.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/db_beanie/models/__init__.py
@@ -1,0 +1,1 @@
+"""{{cookiecutter.project_name}} models."""

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/db_beanie/models/dummy_model.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/db_beanie/models/dummy_model.py
@@ -1,0 +1,5 @@
+from beanie import Document
+
+class DummyModel(Document):
+    """Model for demo purpose."""
+    name: str

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/settings.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/settings.py
@@ -56,7 +56,11 @@ class Settings(BaseSettings):
     db_port: int = {{cookiecutter.db_info.port}}
     db_user: str = "{{cookiecutter.project_name}}"
     db_pass: str = "{{cookiecutter.project_name}}"
+    {%- if cookiecutter.db_info.name != "sqlite" %}
+    db_base: str = "admin"
+    {%- else %}
     db_base: str = "{{cookiecutter.project_name}}"
+    {%- endif %}
     {%- endif %}
     db_echo: bool = False
 

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/tests/test_dummy.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/tests/test_dummy.py
@@ -62,7 +62,7 @@ async def test_creation(
 
     {%- if cookiecutter.orm == "beanie" %}
     instance = await DummyModel.find(DummyModel.name == test_name).first_or_none()
-    assert instance.name == test_name
+    assert instance is not None and instance.name == test_name
     {%- else %}
     instances = await dao.filter(name=test_name)
     assert instances[0].name == test_name

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/dummy/schema.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/dummy/schema.py
@@ -25,6 +25,10 @@ class DummyModelDTO(BaseModel):
     @field_validator("id", mode="before")
     @classmethod
     def parse_object_id(cls, document_id: ObjectId) -> str:
+        """
+        Validator for turning an incoming `ObjectId` into a
+        json serializable `str`.
+        """
         return str(document_id)
     {%- endif %}
     name: str

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/dummy/schema.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/dummy/schema.py
@@ -4,6 +4,10 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 
 {%- endif %}
+{%- if cookiecutter.db_info.name == "mongodb" %}
+from pydantic import field_validator
+from bson import ObjectId
+{%- endif %}
 
 
 class DummyModelDTO(BaseModel):
@@ -13,7 +17,16 @@ class DummyModelDTO(BaseModel):
     It returned when accessing dummy models from the API.
     """
 
+    {%- if cookiecutter.dbinfo.name != "mongodb" %}
     id: int
+    {%- else %}
+    id: str
+
+    @field_validator("id", mode="before")
+    @classmethod
+    def parse_object_id(cls, document_id: ObjectId) -> str:
+        return str(document_id)
+    {%- endif %}
     name: str
 
 

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/dummy/schema.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/dummy/schema.py
@@ -17,7 +17,7 @@ class DummyModelDTO(BaseModel):
     It returned when accessing dummy models from the API.
     """
 
-    {%- if cookiecutter.dbinfo.name != "mongodb" %}
+    {%- if cookiecutter.db_info.name != "mongodb" %}
     id: int
     {%- else %}
     id: str

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/dummy/schema.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/dummy/schema.py
@@ -21,7 +21,10 @@ class DummyModelDTO(BaseModel):
     id: int
     {%- else %}
     id: str
+    {%- endif %}
+    name: str
 
+    {%- if cookiecutter.db_info.name == "mongodb" %}
     @field_validator("id", mode="before")
     @classmethod
     def parse_object_id(cls, document_id: ObjectId) -> str:
@@ -31,7 +34,6 @@ class DummyModelDTO(BaseModel):
         """
         return str(document_id)
     {%- endif %}
-    name: str
 
 
     {%- if cookiecutter.pydanticv1 == "True" %}

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/dummy/views.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/api/dummy/views.py
@@ -2,7 +2,9 @@ from typing import List
 
 from fastapi import APIRouter
 from fastapi.param_functions import Depends
+{%- if cookiecutter.db_info.name != "mongodb" %}
 from {{cookiecutter.project_name}}.db.dao.dummy_dao import DummyDAO
+{%- endif %}
 from {{cookiecutter.project_name}}.db.models.dummy_model import DummyModel
 from {{cookiecutter.project_name}}.web.api.dummy.schema import (DummyModelDTO,
                                                                 DummyModelInputDTO)
@@ -14,28 +16,44 @@ router = APIRouter()
 async def get_dummy_models(
     limit: int = 10,
     offset: int = 0,
+{%- if cookiecutter.db_info.name != "mongodb" %}
     dummy_dao: DummyDAO = Depends(),
+{%- endif %}
 ) -> List[DummyModel]:
     """
     Retrieve all dummy objects from the database.
 
     :param limit: limit of dummy objects, defaults to 10.
     :param offset: offset of dummy objects, defaults to 0.
+{%- if cookiecutter.db_info.name != "mongodb" %}
     :param dummy_dao: DAO for dummy models.
+{%- endif %}
     :return: list of dummy objects from database.
     """
+{%- if cookiecutter.db_info.name != "mongodb" %}
     return await dummy_dao.get_all_dummies(limit=limit, offset=offset)
+{%- else %}
+    return await DummyModel.find_all(skip=offset, limit=limit).to_list()
+{%- endif %}
 
 
 @router.put("/")
 async def create_dummy_model(
     new_dummy_object: DummyModelInputDTO,
+{%- if cookiecutter.db_info.name != "mongodb" %}
     dummy_dao: DummyDAO = Depends(),
+{%- endif %}
 ) -> None:
     """
     Creates dummy model in the database.
 
     :param new_dummy_object: new dummy model item.
+{%- if cookiecutter.db_info.name != "mongodb" %}
     :param dummy_dao: DAO for dummy models.
+{%- endif %}
     """
+{%- if cookiecutter.db_info.name != "mongodb" %}
     await dummy_dao.create_dummy_model(name=new_dummy_object.name)
+{%- else %}
+    await DummyModel.insert_one(DummyModel(name=new_dummy_object.name))
+{%- endif %}

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/lifetime.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/lifetime.py
@@ -120,6 +120,24 @@ def _setup_db(app: FastAPI) -> None:  # pragma: no cover
     app.state.db_session_factory = session_factory
 {%- endif %}
 
+{%- if cookiecutter.orm == "beanie" %}
+import beanie
+from motor.motor_asyncio import AsyncIOMotorClient
+from {{cookiecutter.projecT_name}}.db.models.dummy_model import DummyModel
+async def _setup_db(app: FastAPI) -> None:
+    client = AsyncIOMotorClient(
+        f"mongodb://{settings.db_user}:{settings.db_pass}"
+        + f"@{settings.db_host}:{settings.db_port}/{settings.db_base}"
+    )
+    app.state.db_client = client
+    await beanie.init_beanie(
+        database=client[settings.db_base],
+        document_models=[
+            DummyModel, # type: ignore
+        ]
+    )
+{%- endif %}
+
 {%- if cookiecutter.enable_migrations != "True" %}
 {%- if cookiecutter.orm in ["ormar", "sqlalchemy"] %}
 async def _create_tables() -> None:  # pragma: no cover
@@ -276,7 +294,7 @@ def register_startup_event(app: FastAPI) -> Callable[[], Awaitable[None]]:  # pr
         _setup_db(app)
         {%- elif cookiecutter.orm == "ormar" %}
         await database.connect()
-        {%- elif cookiecutter.orm == "psycopg" %}
+        {%- elif cookiecutter.orm in ["beanie", "psycopg"] %}
         await _setup_db(app)
         {%- endif %}
         {%- if cookiecutter.db_info.name != "none" and cookiecutter.enable_migrations != "True" %}

--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/lifetime.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/lifetime.py
@@ -123,7 +123,7 @@ def _setup_db(app: FastAPI) -> None:  # pragma: no cover
 {%- if cookiecutter.orm == "beanie" %}
 import beanie
 from motor.motor_asyncio import AsyncIOMotorClient
-from {{cookiecutter.projecT_name}}.db.models.dummy_model import DummyModel
+from {{cookiecutter.project_name}}.db.models.dummy_model import DummyModel
 async def _setup_db(app: FastAPI) -> None:
     client = AsyncIOMotorClient(
         f"mongodb://{settings.db_user}:{settings.db_pass}"

--- a/poetry.lock
+++ b/poetry.lock
@@ -303,6 +303,79 @@ docs = ["furo (>=2023.5.20)", "sphinx (>=7.0.1)", "sphinx-autodoc-typehints (>=1
 testing = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "diff-cover (>=7.5)", "pytest (>=7.3.1)", "pytest-cov (>=4.1)", "pytest-mock (>=3.10)", "pytest-timeout (>=2.1)"]
 
 [[package]]
+name = "greenlet"
+version = "2.0.2"
+description = "Lightweight in-process concurrent programming"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
+files = [
+    {file = "greenlet-2.0.2-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:bdfea8c661e80d3c1c99ad7c3ff74e6e87184895bbaca6ee8cc61209f8b9b85d"},
+    {file = "greenlet-2.0.2-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:9d14b83fab60d5e8abe587d51c75b252bcc21683f24699ada8fb275d7712f5a9"},
+    {file = "greenlet-2.0.2-cp27-cp27m-win32.whl", hash = "sha256:6c3acb79b0bfd4fe733dff8bc62695283b57949ebcca05ae5c129eb606ff2d74"},
+    {file = "greenlet-2.0.2-cp27-cp27m-win_amd64.whl", hash = "sha256:283737e0da3f08bd637b5ad058507e578dd462db259f7f6e4c5c365ba4ee9343"},
+    {file = "greenlet-2.0.2-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:d27ec7509b9c18b6d73f2f5ede2622441de812e7b1a80bbd446cb0633bd3d5ae"},
+    {file = "greenlet-2.0.2-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:30bcf80dda7f15ac77ba5af2b961bdd9dbc77fd4ac6105cee85b0d0a5fcf74df"},
+    {file = "greenlet-2.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26fbfce90728d82bc9e6c38ea4d038cba20b7faf8a0ca53a9c07b67318d46088"},
+    {file = "greenlet-2.0.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9190f09060ea4debddd24665d6804b995a9c122ef5917ab26e1566dcc712ceeb"},
+    {file = "greenlet-2.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d75209eed723105f9596807495d58d10b3470fa6732dd6756595e89925ce2470"},
+    {file = "greenlet-2.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:3a51c9751078733d88e013587b108f1b7a1fb106d402fb390740f002b6f6551a"},
+    {file = "greenlet-2.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:76ae285c8104046b3a7f06b42f29c7b73f77683df18c49ab5af7983994c2dd91"},
+    {file = "greenlet-2.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:2d4686f195e32d36b4d7cf2d166857dbd0ee9f3d20ae349b6bf8afc8485b3645"},
+    {file = "greenlet-2.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c4302695ad8027363e96311df24ee28978162cdcdd2006476c43970b384a244c"},
+    {file = "greenlet-2.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c48f54ef8e05f04d6eff74b8233f6063cb1ed960243eacc474ee73a2ea8573ca"},
+    {file = "greenlet-2.0.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a1846f1b999e78e13837c93c778dcfc3365902cfb8d1bdb7dd73ead37059f0d0"},
+    {file = "greenlet-2.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a06ad5312349fec0ab944664b01d26f8d1f05009566339ac6f63f56589bc1a2"},
+    {file = "greenlet-2.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:eff4eb9b7eb3e4d0cae3d28c283dc16d9bed6b193c2e1ace3ed86ce48ea8df19"},
+    {file = "greenlet-2.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5454276c07d27a740c5892f4907c86327b632127dd9abec42ee62e12427ff7e3"},
+    {file = "greenlet-2.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:7cafd1208fdbe93b67c7086876f061f660cfddc44f404279c1585bbf3cdc64c5"},
+    {file = "greenlet-2.0.2-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:910841381caba4f744a44bf81bfd573c94e10b3045ee00de0cbf436fe50673a6"},
+    {file = "greenlet-2.0.2-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:18a7f18b82b52ee85322d7a7874e676f34ab319b9f8cce5de06067384aa8ff43"},
+    {file = "greenlet-2.0.2-cp35-cp35m-win32.whl", hash = "sha256:03a8f4f3430c3b3ff8d10a2a86028c660355ab637cee9333d63d66b56f09d52a"},
+    {file = "greenlet-2.0.2-cp35-cp35m-win_amd64.whl", hash = "sha256:4b58adb399c4d61d912c4c331984d60eb66565175cdf4a34792cd9600f21b394"},
+    {file = "greenlet-2.0.2-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:703f18f3fda276b9a916f0934d2fb6d989bf0b4fb5a64825260eb9bfd52d78f0"},
+    {file = "greenlet-2.0.2-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:32e5b64b148966d9cccc2c8d35a671409e45f195864560829f395a54226408d3"},
+    {file = "greenlet-2.0.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2dd11f291565a81d71dab10b7033395b7a3a5456e637cf997a6f33ebdf06f8db"},
+    {file = "greenlet-2.0.2-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0f72c9ddb8cd28532185f54cc1453f2c16fb417a08b53a855c4e6a418edd099"},
+    {file = "greenlet-2.0.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd021c754b162c0fb55ad5d6b9d960db667faad0fa2ff25bb6e1301b0b6e6a75"},
+    {file = "greenlet-2.0.2-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:3c9b12575734155d0c09d6c3e10dbd81665d5c18e1a7c6597df72fd05990c8cf"},
+    {file = "greenlet-2.0.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:b9ec052b06a0524f0e35bd8790686a1da006bd911dd1ef7d50b77bfbad74e292"},
+    {file = "greenlet-2.0.2-cp36-cp36m-win32.whl", hash = "sha256:dbfcfc0218093a19c252ca8eb9aee3d29cfdcb586df21049b9d777fd32c14fd9"},
+    {file = "greenlet-2.0.2-cp36-cp36m-win_amd64.whl", hash = "sha256:9f35ec95538f50292f6d8f2c9c9f8a3c6540bbfec21c9e5b4b751e0a7c20864f"},
+    {file = "greenlet-2.0.2-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:d5508f0b173e6aa47273bdc0a0b5ba055b59662ba7c7ee5119528f466585526b"},
+    {file = "greenlet-2.0.2-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:f82d4d717d8ef19188687aa32b8363e96062911e63ba22a0cff7802a8e58e5f1"},
+    {file = "greenlet-2.0.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c9c59a2120b55788e800d82dfa99b9e156ff8f2227f07c5e3012a45a399620b7"},
+    {file = "greenlet-2.0.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2780572ec463d44c1d3ae850239508dbeb9fed38e294c68d19a24d925d9223ca"},
+    {file = "greenlet-2.0.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:937e9020b514ceedb9c830c55d5c9872abc90f4b5862f89c0887033ae33c6f73"},
+    {file = "greenlet-2.0.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:36abbf031e1c0f79dd5d596bfaf8e921c41df2bdf54ee1eed921ce1f52999a86"},
+    {file = "greenlet-2.0.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:18e98fb3de7dba1c0a852731c3070cf022d14f0d68b4c87a19cc1016f3bb8b33"},
+    {file = "greenlet-2.0.2-cp37-cp37m-win32.whl", hash = "sha256:3f6ea9bd35eb450837a3d80e77b517ea5bc56b4647f5502cd28de13675ee12f7"},
+    {file = "greenlet-2.0.2-cp37-cp37m-win_amd64.whl", hash = "sha256:7492e2b7bd7c9b9916388d9df23fa49d9b88ac0640db0a5b4ecc2b653bf451e3"},
+    {file = "greenlet-2.0.2-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:b864ba53912b6c3ab6bcb2beb19f19edd01a6bfcbdfe1f37ddd1778abfe75a30"},
+    {file = "greenlet-2.0.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:ba2956617f1c42598a308a84c6cf021a90ff3862eddafd20c3333d50f0edb45b"},
+    {file = "greenlet-2.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc3a569657468b6f3fb60587e48356fe512c1754ca05a564f11366ac9e306526"},
+    {file = "greenlet-2.0.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8eab883b3b2a38cc1e050819ef06a7e6344d4a990d24d45bc6f2cf959045a45b"},
+    {file = "greenlet-2.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acd2162a36d3de67ee896c43effcd5ee3de247eb00354db411feb025aa319857"},
+    {file = "greenlet-2.0.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:0bf60faf0bc2468089bdc5edd10555bab6e85152191df713e2ab1fcc86382b5a"},
+    {file = "greenlet-2.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b0ef99cdbe2b682b9ccbb964743a6aca37905fda5e0452e5ee239b1654d37f2a"},
+    {file = "greenlet-2.0.2-cp38-cp38-win32.whl", hash = "sha256:b80f600eddddce72320dbbc8e3784d16bd3fb7b517e82476d8da921f27d4b249"},
+    {file = "greenlet-2.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:4d2e11331fc0c02b6e84b0d28ece3a36e0548ee1a1ce9ddde03752d9b79bba40"},
+    {file = "greenlet-2.0.2-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:88d9ab96491d38a5ab7c56dd7a3cc37d83336ecc564e4e8816dbed12e5aaefc8"},
+    {file = "greenlet-2.0.2-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:561091a7be172ab497a3527602d467e2b3fbe75f9e783d8b8ce403fa414f71a6"},
+    {file = "greenlet-2.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:971ce5e14dc5e73715755d0ca2975ac88cfdaefcaab078a284fea6cfabf866df"},
+    {file = "greenlet-2.0.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be4ed120b52ae4d974aa40215fcdfde9194d63541c7ded40ee12eb4dda57b76b"},
+    {file = "greenlet-2.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94c817e84245513926588caf1152e3b559ff794d505555211ca041f032abbb6b"},
+    {file = "greenlet-2.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:1a819eef4b0e0b96bb0d98d797bef17dc1b4a10e8d7446be32d1da33e095dbb8"},
+    {file = "greenlet-2.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:7efde645ca1cc441d6dc4b48c0f7101e8d86b54c8530141b09fd31cef5149ec9"},
+    {file = "greenlet-2.0.2-cp39-cp39-win32.whl", hash = "sha256:ea9872c80c132f4663822dd2a08d404073a5a9b5ba6155bea72fb2a79d1093b5"},
+    {file = "greenlet-2.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:db1a39669102a1d8d12b57de2bb7e2ec9066a6f2b3da35ae511ff93b01b5d564"},
+    {file = "greenlet-2.0.2.tar.gz", hash = "sha256:e7c8dc13af7db097bed64a051d2dd49e9f0af495c26995c00a9ee842690d34c0"},
+]
+
+[package.extras]
+docs = ["Sphinx", "docutils (<0.18)"]
+test = ["objgraph", "psutil"]
+
+[[package]]
 name = "identify"
 version = "2.5.24"
 description = "File identification library for Python"
@@ -427,6 +500,78 @@ files = [
     {file = "MarkupSafe-2.1.3-cp39-cp39-win32.whl", hash = "sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2"},
     {file = "MarkupSafe-2.1.3-cp39-cp39-win_amd64.whl", hash = "sha256:3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba"},
     {file = "MarkupSafe-2.1.3.tar.gz", hash = "sha256:af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad"},
+]
+
+[[package]]
+name = "msgpack"
+version = "1.0.5"
+description = "MessagePack serializer"
+optional = false
+python-versions = "*"
+files = [
+    {file = "msgpack-1.0.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:525228efd79bb831cf6830a732e2e80bc1b05436b086d4264814b4b2955b2fa9"},
+    {file = "msgpack-1.0.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4f8d8b3bf1ff2672567d6b5c725a1b347fe838b912772aa8ae2bf70338d5a198"},
+    {file = "msgpack-1.0.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cdc793c50be3f01106245a61b739328f7dccc2c648b501e237f0699fe1395b81"},
+    {file = "msgpack-1.0.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cb47c21a8a65b165ce29f2bec852790cbc04936f502966768e4aae9fa763cb7"},
+    {file = "msgpack-1.0.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e42b9594cc3bf4d838d67d6ed62b9e59e201862a25e9a157019e171fbe672dd3"},
+    {file = "msgpack-1.0.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:55b56a24893105dc52c1253649b60f475f36b3aa0fc66115bffafb624d7cb30b"},
+    {file = "msgpack-1.0.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:1967f6129fc50a43bfe0951c35acbb729be89a55d849fab7686004da85103f1c"},
+    {file = "msgpack-1.0.5-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:20a97bf595a232c3ee6d57ddaadd5453d174a52594bf9c21d10407e2a2d9b3bd"},
+    {file = "msgpack-1.0.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d25dd59bbbbb996eacf7be6b4ad082ed7eacc4e8f3d2df1ba43822da9bfa122a"},
+    {file = "msgpack-1.0.5-cp310-cp310-win32.whl", hash = "sha256:382b2c77589331f2cb80b67cc058c00f225e19827dbc818d700f61513ab47bea"},
+    {file = "msgpack-1.0.5-cp310-cp310-win_amd64.whl", hash = "sha256:4867aa2df9e2a5fa5f76d7d5565d25ec76e84c106b55509e78c1ede0f152659a"},
+    {file = "msgpack-1.0.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9f5ae84c5c8a857ec44dc180a8b0cc08238e021f57abdf51a8182e915e6299f0"},
+    {file = "msgpack-1.0.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9e6ca5d5699bcd89ae605c150aee83b5321f2115695e741b99618f4856c50898"},
+    {file = "msgpack-1.0.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5494ea30d517a3576749cad32fa27f7585c65f5f38309c88c6d137877fa28a5a"},
+    {file = "msgpack-1.0.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1ab2f3331cb1b54165976a9d976cb251a83183631c88076613c6c780f0d6e45a"},
+    {file = "msgpack-1.0.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28592e20bbb1620848256ebc105fc420436af59515793ed27d5c77a217477705"},
+    {file = "msgpack-1.0.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fe5c63197c55bce6385d9aee16c4d0641684628f63ace85f73571e65ad1c1e8d"},
+    {file = "msgpack-1.0.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ed40e926fa2f297e8a653c954b732f125ef97bdd4c889f243182299de27e2aa9"},
+    {file = "msgpack-1.0.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:b2de4c1c0538dcb7010902a2b97f4e00fc4ddf2c8cda9749af0e594d3b7fa3d7"},
+    {file = "msgpack-1.0.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:bf22a83f973b50f9d38e55c6aade04c41ddda19b00c4ebc558930d78eecc64ed"},
+    {file = "msgpack-1.0.5-cp311-cp311-win32.whl", hash = "sha256:c396e2cc213d12ce017b686e0f53497f94f8ba2b24799c25d913d46c08ec422c"},
+    {file = "msgpack-1.0.5-cp311-cp311-win_amd64.whl", hash = "sha256:6c4c68d87497f66f96d50142a2b73b97972130d93677ce930718f68828b382e2"},
+    {file = "msgpack-1.0.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:a2b031c2e9b9af485d5e3c4520f4220d74f4d222a5b8dc8c1a3ab9448ca79c57"},
+    {file = "msgpack-1.0.5-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f837b93669ce4336e24d08286c38761132bc7ab29782727f8557e1eb21b2080"},
+    {file = "msgpack-1.0.5-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1d46dfe3832660f53b13b925d4e0fa1432b00f5f7210eb3ad3bb9a13c6204a6"},
+    {file = "msgpack-1.0.5-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:366c9a7b9057e1547f4ad51d8facad8b406bab69c7d72c0eb6f529cf76d4b85f"},
+    {file = "msgpack-1.0.5-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:4c075728a1095efd0634a7dccb06204919a2f67d1893b6aa8e00497258bf926c"},
+    {file = "msgpack-1.0.5-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:f933bbda5a3ee63b8834179096923b094b76f0c7a73c1cfe8f07ad608c58844b"},
+    {file = "msgpack-1.0.5-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:36961b0568c36027c76e2ae3ca1132e35123dcec0706c4b7992683cc26c1320c"},
+    {file = "msgpack-1.0.5-cp36-cp36m-win32.whl", hash = "sha256:b5ef2f015b95f912c2fcab19c36814963b5463f1fb9049846994b007962743e9"},
+    {file = "msgpack-1.0.5-cp36-cp36m-win_amd64.whl", hash = "sha256:288e32b47e67f7b171f86b030e527e302c91bd3f40fd9033483f2cacc37f327a"},
+    {file = "msgpack-1.0.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:137850656634abddfb88236008339fdaba3178f4751b28f270d2ebe77a563b6c"},
+    {file = "msgpack-1.0.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c05a4a96585525916b109bb85f8cb6511db1c6f5b9d9cbcbc940dc6b4be944b"},
+    {file = "msgpack-1.0.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56a62ec00b636583e5cb6ad313bbed36bb7ead5fa3a3e38938503142c72cba4f"},
+    {file = "msgpack-1.0.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ef8108f8dedf204bb7b42994abf93882da1159728a2d4c5e82012edd92c9da9f"},
+    {file = "msgpack-1.0.5-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:1835c84d65f46900920b3708f5ba829fb19b1096c1800ad60bae8418652a951d"},
+    {file = "msgpack-1.0.5-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:e57916ef1bd0fee4f21c4600e9d1da352d8816b52a599c46460e93a6e9f17086"},
+    {file = "msgpack-1.0.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:17358523b85973e5f242ad74aa4712b7ee560715562554aa2134d96e7aa4cbbf"},
+    {file = "msgpack-1.0.5-cp37-cp37m-win32.whl", hash = "sha256:cb5aaa8c17760909ec6cb15e744c3ebc2ca8918e727216e79607b7bbce9c8f77"},
+    {file = "msgpack-1.0.5-cp37-cp37m-win_amd64.whl", hash = "sha256:ab31e908d8424d55601ad7075e471b7d0140d4d3dd3272daf39c5c19d936bd82"},
+    {file = "msgpack-1.0.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:b72d0698f86e8d9ddf9442bdedec15b71df3598199ba33322d9711a19f08145c"},
+    {file = "msgpack-1.0.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:379026812e49258016dd84ad79ac8446922234d498058ae1d415f04b522d5b2d"},
+    {file = "msgpack-1.0.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:332360ff25469c346a1c5e47cbe2a725517919892eda5cfaffe6046656f0b7bb"},
+    {file = "msgpack-1.0.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:476a8fe8fae289fdf273d6d2a6cb6e35b5a58541693e8f9f019bfe990a51e4ba"},
+    {file = "msgpack-1.0.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9985b214f33311df47e274eb788a5893a761d025e2b92c723ba4c63936b69b1"},
+    {file = "msgpack-1.0.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:48296af57cdb1d885843afd73c4656be5c76c0c6328db3440c9601a98f303d87"},
+    {file = "msgpack-1.0.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:addab7e2e1fcc04bd08e4eb631c2a90960c340e40dfc4a5e24d2ff0d5a3b3edb"},
+    {file = "msgpack-1.0.5-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:916723458c25dfb77ff07f4c66aed34e47503b2eb3188b3adbec8d8aa6e00f48"},
+    {file = "msgpack-1.0.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:821c7e677cc6acf0fd3f7ac664c98803827ae6de594a9f99563e48c5a2f27eb0"},
+    {file = "msgpack-1.0.5-cp38-cp38-win32.whl", hash = "sha256:1c0f7c47f0087ffda62961d425e4407961a7ffd2aa004c81b9c07d9269512f6e"},
+    {file = "msgpack-1.0.5-cp38-cp38-win_amd64.whl", hash = "sha256:bae7de2026cbfe3782c8b78b0db9cbfc5455e079f1937cb0ab8d133496ac55e1"},
+    {file = "msgpack-1.0.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:20c784e66b613c7f16f632e7b5e8a1651aa5702463d61394671ba07b2fc9e025"},
+    {file = "msgpack-1.0.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:266fa4202c0eb94d26822d9bfd7af25d1e2c088927fe8de9033d929dd5ba24c5"},
+    {file = "msgpack-1.0.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:18334484eafc2b1aa47a6d42427da7fa8f2ab3d60b674120bce7a895a0a85bdd"},
+    {file = "msgpack-1.0.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57e1f3528bd95cc44684beda696f74d3aaa8a5e58c816214b9046512240ef437"},
+    {file = "msgpack-1.0.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:586d0d636f9a628ddc6a17bfd45aa5b5efaf1606d2b60fa5d87b8986326e933f"},
+    {file = "msgpack-1.0.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a740fa0e4087a734455f0fc3abf5e746004c9da72fbd541e9b113013c8dc3282"},
+    {file = "msgpack-1.0.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:3055b0455e45810820db1f29d900bf39466df96ddca11dfa6d074fa47054376d"},
+    {file = "msgpack-1.0.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:a61215eac016f391129a013c9e46f3ab308db5f5ec9f25811e811f96962599a8"},
+    {file = "msgpack-1.0.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:362d9655cd369b08fda06b6657a303eb7172d5279997abe094512e919cf74b11"},
+    {file = "msgpack-1.0.5-cp39-cp39-win32.whl", hash = "sha256:ac9dd47af78cae935901a9a500104e2dea2e253207c924cc95de149606dc43cc"},
+    {file = "msgpack-1.0.5-cp39-cp39-win_amd64.whl", hash = "sha256:06f5174b5f8ed0ed919da0e62cbd4ffde676a374aba4020034da05fab67b9164"},
+    {file = "msgpack-1.0.5.tar.gz", hash = "sha256:c075544284eadc5cddc70f4757331d99dcbc16b2bbd4849d15f8aae4cf36d31c"},
 ]
 
 [[package]]
@@ -709,6 +854,24 @@ files = [
 
 [package.extras]
 plugins = ["importlib-metadata"]
+
+[[package]]
+name = "pynvim"
+version = "0.4.3"
+description = "Python client to neovim"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pynvim-0.4.3.tar.gz", hash = "sha256:3a795378bde5e8092fbeb3a1a99be9c613d2685542f1db0e5c6fd467eed56dff"},
+]
+
+[package.dependencies]
+greenlet = "*"
+msgpack = ">=0.5.0"
+
+[package.extras]
+pyuv = ["pyuv (>=1.0.0)"]
+test = ["pytest (>=3.4.0)"]
 
 [[package]]
 name = "pytest"
@@ -1070,4 +1233,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "ca51e2183f25683e533c30357685e4bcf8c0d75d92586fca2dbb0dfc20833908"
+content-hash = "0a368636e28b463e5fc8e4935db409a8e1870996c19f185585305ade47beee84"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ pytest-env = "^0.6.2"
 Faker = "^8.14.0"
 pytest-xdist = {version = "^2.5.0", extras = ["psutil"]}
 requests = "^2.28.1"
+pynvim = "^0.4.3"
 
 [tool.pytest.ini_options]
 minversion = "6.0"


### PR DESCRIPTION
Adds support for MongoDB and Beanie. Probably fixes #119 ?

I did a simple crud app with virtually the same setup, seems to be working fine.

## Demos
- project setup: https://asciinema.org/a/U5YaCeweA4vGqmNCv5zpBpwSc
- deploying MongoDB and starting the application: https://asciinema.org/a/XOq7NByeER8kC3tT0cLFsW2gO
- a simple crud app: https://github.com/usefulalgorithm/fastapi-mongo-demo-app/
  - some differences between this project and this PR:
    - `db` service is placed in `docker-compose.dev.yaml` instead of `docker-compose.yml`
    - `Settings` has a separate section for mongodb settings

## Todos / caveats / things to note:
- MongoDB requires additional setup if you're not writing to the `admin` database
- Some docstring and comments are probably off, and flake is likely to complain.
- I have no idea how cookiecutter works, so I basically did it like how I use Jinja templates and tried to fill in as many gaps as possible. I'm guessing I probably missed a lot of places...
- The only setup I tested is the one in the clip.