### PR TITLE
Fixes sentry sdk import module

### DIFF
--- a/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/application.py
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/web/application.py
@@ -22,7 +22,7 @@ from {{cookiecutter.project_name}}.db.config import TORTOISE_CONFIG
 {%- if cookiecutter.sentry_enabled == "True" %}
 import sentry_sdk
 from sentry_sdk.integrations.fastapi import FastApiIntegration
-from sentry_sdk.integrations.log import LoggingIntegration
+from sentry_sdk.integrations.logging import LoggingIntegration
 
 {%- if cookiecutter.orm == "sqlalchemy" %}
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration


### PR DESCRIPTION
Got this error when trying to setup a project using sentry
```bash
api-1       |     from sentry_sdk.integrations.log import LoggingIntegration
api-1       | ModuleNotFoundError: No module named 'sentry_sdk.integrations.log'
```
I can't find any `sentry_sdk.integrations.log` from Sentry's API docs (https://getsentry.github.io/sentry-python/integrations.html). But when I changed It to `sentry_sdk.integrations.logging` it worked. 