### PR TITLE
fix: update template CI to use uv and ruff instead of poetry and black

### DIFF
--- a/fastapi_template/template/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -7,23 +7,22 @@ jobs:
     strategy:
       matrix:
         cmd:
-          - black
+          - ruff-format
           - ruff
           - mypy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install poetry
-        run: pipx install poetry
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
-          cache: 'poetry'
+          python-version: '3.12'
+      - name: Set up UV
+        uses: astral-sh/setup-uv@v6
       - name: Install deps
-        run: poetry install
+        run: uv sync
       - name: Run lint check
-        run: poetry run pre-commit run -a {{ '${{' }} matrix.cmd {{ '}}' }}
+        run: uv run pre-commit run -a {{ '${{' }} matrix.cmd {{ '}}' }}
   pytest:
     runs-on: ubuntu-latest
     steps:
@@ -31,13 +30,12 @@ jobs:
       - name: Create .env
         run: touch .env
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Update docker-compose
         uses: KengoTODA/actions-setup-docker-compose@v1
         with:
           version: "2.28.0"
       - name: run tests
         run: docker-compose run --rm api pytest -vv
-

--- a/fastapi_template/template/{{cookiecutter.project_name}}/alembic.ini
+++ b/fastapi_template/template/{{cookiecutter.project_name}}/alembic.ini
@@ -7,14 +7,15 @@ output_encoding = utf-8
 
 
 [post_write_hooks]
-hooks = black,ruff
+hooks = ruff_format,ruff_check
 
-black.type = console_scripts
-black.entrypoint = black
+ruff_format.type = exec
+ruff_format.executable = ruff
+ruff_format.options = format REVISION_SCRIPT_FILENAME
 
-ruff.type = exec
-ruff.executable = ruff
-ruff.options = check --fix REVISION_SCRIPT_FILENAME --ignore N999
+ruff_check.type = exec
+ruff_check.executable = ruff
+ruff_check.options = check --fix REVISION_SCRIPT_FILENAME --ignore N999
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
## Summary

Closes #243

The generated project CI workflow still used Poetry and Black, while `pyproject.toml` and `.pre-commit-config.yaml` already use uv and ruff.

## Changes

**`.github/workflows/tests.yml` (template):**
- Replace `pipx install poetry` + `poetry install` with `astral-sh/setup-uv@v6` + `uv sync`
- Replace `black` with `ruff-format` in lint matrix (matches `.pre-commit-config.yaml` hook IDs)
- Update `actions/setup-python` from v5 to v6
- Update Python from 3.11 to 3.12 (minimum per `pyproject.toml`)
- Remove `cache: 'poetry'` (uv handles its own cache)

**`alembic.ini` (template):**
- Replace `black` post-write hook with `ruff format`
- Rename `ruff` hook to `ruff_check` for clarity

## Before vs After

| Aspect | Before | After |
|--------|--------|-------|
| Dependency manager | Poetry | uv |
| Formatter | Black | ruff format |
| Python version | 3.11 | 3.12 |
| setup-python | v5 | v6 |
| Alembic hooks | black + ruff check | ruff format + ruff check |

## Test plan

- [x] Verified lint matrix IDs (`ruff-format`, `ruff`, `mypy`) match `.pre-commit-config.yaml` hook IDs
- [x] Verified `uv sync` matches root-level CI pattern (`.github/workflows/test.yml`)
- [ ] Generate a project with cookiecutter and verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)